### PR TITLE
Remove + 1 on plain_log bounds

### DIFF
--- a/src/xld_sign.cpp
+++ b/src/xld_sign.cpp
@@ -615,7 +615,7 @@ int main(int argc, char *argv[]) {
       return -3;
     }
 
-    std::string plain_log(log.begin(), log.begin() + sig_start + 1);
+    std::string plain_log(log.begin(), log.begin() + sig_start);
     std::string sig_real = xld_signature(plain_log);
     std::string sig = log.substr(sig_start + 1);
 


### PR DESCRIPTION
Without doing this change, I was getting "Bad Sig" even on perfectly fine XLD logs. Checked on 5 logs I had on my computer against the official XLD Logchecker as well as the Windows version available on Sourceforge.